### PR TITLE
Fix open boundary forcing

### DIFF
--- a/mpi/ice_boundary.F90
+++ b/mpi/ice_boundary.F90
@@ -1294,14 +1294,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:) = fill
-      array(1:nx_block,ny_block-j+1,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:) = fill
-      array(nx_block-i+1,1:ny_block,:) = fill
-   enddo
+!   do j = 1,nghost
+!      array(1:nx_block,           j,:) = fill
+!      array(1:nx_block,ny_block-j+1,:) = fill
+!   enddo
+!   do i = 1,nghost
+!      array(i,           1:ny_block,:) = fill
+!      array(nx_block-i+1,1:ny_block,:) = fill
+!   enddo
 
 !-----------------------------------------------------------------------
 !
@@ -1689,14 +1689,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:) = fill
-      array(1:nx_block,ny_block-j+1,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:) = fill
-      array(nx_block-i+1,1:ny_block,:) = fill
-   enddo
+!   do j = 1,nghost
+!      array(1:nx_block,           j,:) = fill
+!      array(1:nx_block,ny_block-j+1,:) = fill
+!   enddo
+!   do i = 1,nghost
+!      array(i,           1:ny_block,:) = fill
+!      array(nx_block-i+1,1:ny_block,:) = fill
+!   enddo
 
 !-----------------------------------------------------------------------
 !
@@ -2084,14 +2084,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:) = fill
-      array(1:nx_block,ny_block-j+1,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:) = fill
-      array(nx_block-i+1,1:ny_block,:) = fill
-   enddo
+!   do j = 1,nghost
+!      array(1:nx_block,           j,:) = fill
+!      array(1:nx_block,ny_block-j+1,:) = fill
+!   enddo
+!   do i = 1,nghost
+!      array(i,           1:ny_block,:) = fill
+!      array(nx_block-i+1,1:ny_block,:) = fill
+!   enddo
 
 !-----------------------------------------------------------------------
 !
@@ -2508,14 +2508,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:) = fill
-   enddo
+!   do j = 1,nghost
+!      array(1:nx_block,           j,:,:) = fill
+!      array(1:nx_block,ny_block-j+1,:,:) = fill
+!   enddo
+!   do i = 1,nghost
+!      array(i,           1:ny_block,:,:) = fill
+!      array(nx_block-i+1,1:ny_block,:,:) = fill
+!   enddo
 
 !-----------------------------------------------------------------------
 !
@@ -2964,14 +2964,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:) = fill
-   enddo
+!   do j = 1,nghost
+!      array(1:nx_block,           j,:,:) = fill
+!      array(1:nx_block,ny_block-j+1,:,:) = fill
+!   enddo
+!   do i = 1,nghost
+!      array(i,           1:ny_block,:,:) = fill
+!      array(nx_block-i+1,1:ny_block,:,:) = fill
+!   enddo
 
 !-----------------------------------------------------------------------
 !
@@ -3420,14 +3420,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:) = fill
-   enddo
+!   do j = 1,nghost
+!      array(1:nx_block,           j,:,:) = fill
+!      array(1:nx_block,ny_block-j+1,:,:) = fill
+!   enddo
+!   do i = 1,nghost
+!      array(i,           1:ny_block,:,:) = fill
+!      array(nx_block-i+1,1:ny_block,:,:) = fill
+!   enddo
 
 !-----------------------------------------------------------------------
 !
@@ -3880,14 +3880,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:,:) = fill
-   enddo
+!   do j = 1,nghost
+!      array(1:nx_block,           j,:,:,:) = fill
+!      array(1:nx_block,ny_block-j+1,:,:,:) = fill
+!   enddo
+!   do i = 1,nghost
+!      array(i,           1:ny_block,:,:,:) = fill
+!      array(nx_block-i+1,1:ny_block,:,:,:) = fill
+!   enddo
 
 !-----------------------------------------------------------------------
 !
@@ -4360,14 +4360,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:,:) = fill
-   enddo
+!   do j = 1,nghost
+!      array(1:nx_block,           j,:,:,:) = fill
+!      array(1:nx_block,ny_block-j+1,:,:,:) = fill
+!   enddo
+!   do i = 1,nghost
+!      array(i,           1:ny_block,:,:,:) = fill
+!      array(nx_block-i+1,1:ny_block,:,:,:) = fill
+!   enddo
 
 !-----------------------------------------------------------------------
 !
@@ -4840,14 +4840,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   do j = 1,nghost
-      array(1:nx_block,           j,:,:,:) = fill
-      array(1:nx_block,ny_block-j+1,:,:,:) = fill
-   enddo
-   do i = 1,nghost
-      array(i,           1:ny_block,:,:,:) = fill
-      array(nx_block-i+1,1:ny_block,:,:,:) = fill
-   enddo
+!   do j = 1,nghost
+!      array(1:nx_block,           j,:,:,:) = fill
+!      array(1:nx_block,ny_block-j+1,:,:,:) = fill
+!   enddo
+!   do i = 1,nghost
+!      array(i,           1:ny_block,:,:,:) = fill
+!      array(nx_block-i+1,1:ny_block,:,:,:) = fill
+!   enddo
 
 !-----------------------------------------------------------------------
 !

--- a/source/ice_grid.F90
+++ b/source/ice_grid.F90
@@ -1277,6 +1277,7 @@
       use ice_domain_size
       use ice_constants, only: c1, c0, &
               field_loc_center, field_loc_NEcorner, &
+              field_loc_Nface,  field_loc_Eface, &
               field_type_scalar, field_type_angle
       use ice_read_write, only: ice_read_nc
       use ice_gather_scatter, only: scatter_global
@@ -1394,7 +1395,8 @@
       call ice_read_global_nc(fid_grid,1,fieldname,work_g1,diag) !  ANGLE
       call scatter_global(ANGLE, work_g1, master_task, distrb_info, &
                           field_loc_NEcorner, field_type_angle)
-
+      call ice_HaloExtrapolate(ANGLE, distrb_info, &
+                               ew_boundary_type, ns_boundary_type)
 !-----------------------------------------------------------------
       ! cell dimensions
       ! calculate derived quantities from global arrays to preserve
@@ -1403,11 +1405,29 @@
 
       fieldname='htn'
       call ice_read_global_nc(fid_grid,1,fieldname,work_g1,diag) ! HTN
+      call scatter_global(HTN, work_g1, master_task, distrb_info, &
+                          field_loc_Nface, field_type_scalar)
+      call ice_HaloExtrapolate(HTN, distrb_info, &
+                               ew_boundary_type, ns_boundary_type)
+
       call primary_grid_lengths_HTN(work_g1)                  ! dxu, dxt
+      call ice_HaloExtrapolate(dxt, distrb_info, &
+                               ew_boundary_type, ns_boundary_type)
+      call ice_HaloExtrapolate(dxu, distrb_info, &
+                               ew_boundary_type, ns_boundary_type)
 
       fieldname='hte'
       call ice_read_global_nc(fid_grid,1,fieldname,work_g1,diag) ! HTE
+      call scatter_global(HTE, work_g1, master_task, distrb_info, &
+                          field_loc_Eface, field_type_scalar)
+      call ice_HaloExtrapolate(HTE, distrb_info, &
+                               ew_boundary_type, ns_boundary_type)
+
       call primary_grid_lengths_HTE(work_g1)                  ! dyu, dyt
+      call ice_HaloExtrapolate(dyt, distrb_info, &
+                               ew_boundary_type, ns_boundary_type)
+      call ice_HaloExtrapolate(dyu, distrb_info, &
+                               ew_boundary_type, ns_boundary_type)
 
       deallocate(work_g1)
 

--- a/source/ice_restoring.F90
+++ b/source/ice_restoring.F90
@@ -899,7 +899,7 @@
       use ice_domain, only: ew_boundary_type, ns_boundary_type, &
           nblocks, blocks_ice
 !! Added tmask, t2ugrid_vector, u2tgrid_vector 2018/12/20
-      use ice_grid, only: tmask, t2ugrid_vector, u2tgrid_vector
+      use ice_grid, only: tmask, umask, t2ugrid_vector, u2tgrid_vector
 !! Added ice_flux and ice_state 2019/1/11
 !! Changed vicer to hice_ext 2019/2/14
       use ice_flux, only: sst, Tf, Tair, salinz, Tmltz, &
@@ -1007,8 +1007,9 @@
             do n = 1, ncat
             do j = 1, ny_block
             do i = 1, ilo
-               if (uvel(i,j,iblk) > c0 .or. &  ! ice velocity is inward
-              &    uocn(i,j,iblk) > c0) then   ! ocean current is inward
+              if (tmask(i,j,iblk)) then
+                if (uvel(i,j,iblk) > c0 .or. &  ! ice velocity is inward
+                    uocn(i,j,iblk) > c0) then   ! ocean current is inward
                   aicen(i,j,n,iblk) = aicen(i,j,n,iblk) &
                      + (aicen_rest(i,j,n,iblk)-aicen(i,j,n,iblk))*ctime
                   vicen(i,j,n,iblk) = vicen(i,j,n,iblk) &
@@ -1019,16 +1020,19 @@
                      trcrn(i,j,nt,n,iblk) = trcrn(i,j,nt,n,iblk) &
                         + (trcrn_rest(i,j,nt,n,iblk)-trcrn(i,j,nt,n,iblk))*ctime
                   enddo
-               endif
+                endif
+              endif
             enddo
             enddo
             enddo
 
             do j = 1, ny_block
               do i = 1, ilo
-                uvel(i,j,iblk) = uvel(ilo+1,j,iblk)
-                vvel(i,j,iblk) = c0 ! make ice drift strictly normal to boundary
-                strength(i,j,iblk) = strength(ilo+1,j,iblk)
+                if (umask(i,j,iblk)) then
+                  uvel(i,j,iblk) = uvel(ilo+1,j,iblk)
+                  vvel(i,j,iblk) = c0 ! make ice drift strictly normal to boundary
+                  strength(i,j,iblk) = strength(ilo+1,j,iblk)
+                endif
               enddo ! i
             enddo ! j
 
@@ -1052,8 +1056,9 @@
             do n = 1, ncat
             do j = 1, ny_block
             do i = ihi, ibc
-               if (uvel(i,j,iblk) < c0 .or. &  ! ice velocity is inward
-              &    uocn(i,j,iblk) < c0) then   ! ocean current is inward
+              if (tmask(i,j,iblk)) then
+                if (uvel(i,j,iblk) < c0 .or. &  ! ice velocity is inward
+                    uocn(i,j,iblk) < c0) then   ! ocean current is inward
                   aicen(i,j,n,iblk) = aicen(i,j,n,iblk) &
                      + (aicen_rest(i,j,n,iblk)-aicen(i,j,n,iblk))*ctime
                   vicen(i,j,n,iblk) = vicen(i,j,n,iblk) &
@@ -1064,16 +1069,19 @@
                      trcrn(i,j,nt,n,iblk) = trcrn(i,j,nt,n,iblk) &
                         + (trcrn_rest(i,j,nt,n,iblk)-trcrn(i,j,nt,n,iblk))*ctime
                   enddo
-               endif
+                endif
+              endif
             enddo
             enddo
             enddo
 
             do j = 1, ny_block
               do i = ihi, ibc
-               uvel(i,j,iblk) = uvel(ihi-1,j,iblk)
-               vvel(i,j,iblk) = c0
-               strength(i,j,iblk) = strength(ihi-1,j,iblk)
+                if (umask(i,j,iblk)) then
+                  uvel(i,j,iblk) = uvel(ihi-1,j,iblk)
+                  vvel(i,j,iblk) = c0
+                  strength(i,j,iblk) = strength(ihi-1,j,iblk)
+                endif
               enddo ! i
             enddo ! j
 
@@ -1085,8 +1093,9 @@
             do n = 1, ncat
             do j = 1, jlo
             do i = 1, nx_block
-               if (vvel(i,j,iblk) > c0 .or. &  ! ice velocity is inward
-              &    vocn(i,j,iblk) > c0) then   ! ocean current is inward
+              if (tmask(i,j,iblk)) then
+                if (vvel(i,j,iblk) > c0 .or. &  ! ice velocity is inward
+                    vocn(i,j,iblk) > c0) then   ! ocean current is inward
                   aicen(i,j,n,iblk) = aicen(i,j,n,iblk) &
                      + (aicen_rest(i,j,n,iblk)-aicen(i,j,n,iblk))*ctime
                   vicen(i,j,n,iblk) = vicen(i,j,n,iblk) &
@@ -1097,16 +1106,19 @@
                      trcrn(i,j,nt,n,iblk) = trcrn(i,j,nt,n,iblk) &
                         + (trcrn_rest(i,j,nt,n,iblk)-trcrn(i,j,nt,n,iblk))*ctime
                   enddo
-               endif
+                endif
+              endif
             enddo
             enddo
             enddo
 
             do j = 1, jlo
               do i = 1, nx_block
-               uvel(i,j,iblk) = c0
-               vvel(i,j,iblk) = vvel(i,jlo+1,iblk)
-               strength(i,j,iblk) = strength(i,jlo+1,iblk)
+                if (umask(i,j,iblk)) then
+                  uvel(i,j,iblk) = c0
+                  vvel(i,j,iblk) = vvel(i,jlo+1,iblk)
+                  strength(i,j,iblk) = strength(i,jlo+1,iblk)
+                endif
               enddo ! i
             enddo ! j
 
@@ -1132,8 +1144,9 @@
             do n = 1, ncat
             do j = jhi, ibc
             do i = 1, nx_block
-               if (vvel(i,j,iblk) < c0 .or. &  ! ice velocity is inward
-              &    vocn(i,j,iblk) < c0) then   ! ocean current is inward
+              if (tmask(i,j,iblk)) then
+                if (vvel(i,j,iblk) < c0 .or. &  ! ice velocity is inward
+                    vocn(i,j,iblk) < c0) then   ! ocean current is inward
                   aicen(i,j,n,iblk) = aicen(i,j,n,iblk) &
                      + (aicen_rest(i,j,n,iblk)-aicen(i,j,n,iblk))*ctime
                   vicen(i,j,n,iblk) = vicen(i,j,n,iblk) &
@@ -1144,16 +1157,19 @@
                      trcrn(i,j,nt,n,iblk) = trcrn(i,j,nt,n,iblk) &
                         + (trcrn_rest(i,j,nt,n,iblk)-trcrn(i,j,nt,n,iblk))*ctime
                   enddo
-               endif
+                endif
+              endif
             enddo
             enddo
             enddo
 
             do j = jhi, ibc
               do i = 1, nx_block
-               uvel(i,j,iblk) = c0
-               vvel(i,j,iblk) = vvel(i,jhi-1,iblk)
-               strength(i,j,iblk) = strength(i,jhi-1,iblk)
+                if (umask(i,j,iblk)) then
+                  uvel(i,j,iblk) = c0
+                  vvel(i,j,iblk) = vvel(i,jhi-1,iblk)
+                  strength(i,j,iblk) = strength(i,jhi-1,iblk)
+                endif
               enddo ! i
             enddo ! j
 


### PR DESCRIPTION
The open boundary forcing in CICE is only applied when the flow (ice drift or ocean current) is into the domain. The use of land masks fixes the problem of negative areas of open water along the boundaries. The ice drift at the boundaries is strictly normal.